### PR TITLE
feature/#65 html, css 저장 기능 구현

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -29,13 +29,9 @@ const Header = () => {
   };
 
   const onClickExportHandler = () => {
-    alert('html css가 복사가 완료되었습니다.');
-    const input = document.createElement('input');
-
     const style = window.getComputedStyle(
       document.querySelector('.mq-root-block')
     ) as any;
-    input.setAttribute('value', JSON.stringify(style));
     saveAsFile(mathQuiiFunc.html(), 'html.txt');
     saveAsFile(JSON.stringify(style), 'css.txt');
   };

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -5,12 +5,16 @@ import colors from '@src/utils/colors';
 import html2canvas from 'html2canvas';
 import { RootState } from '@src/store/modules';
 import { useSelector, useDispatch } from 'react-redux';
+import saveAsFile from '@src/utils/savefile';
 import HeaderTitle from './HeaderTitle';
 import * as StyleComponent from './style';
 
 const Header = () => {
   const { mathQuillContainer } = useSelector(
     (state: RootState) => state.getMathQuillReducer
+  );
+  const { mathQuiiFunc } = useSelector(
+    (state: RootState) => state.mathQuillReducer
   );
   const onClickImageSaveHandler = async () => {
     const mathquillSection = mathQuillContainer.current;
@@ -23,8 +27,17 @@ const Header = () => {
     aTag.click();
     document.body.removeChild(aTag);
   };
+
   const onClickExportHandler = () => {
-    console.log('export ');
+    alert('html css가 복사가 완료되었습니다.');
+    const input = document.createElement('input');
+
+    const style = window.getComputedStyle(
+      document.querySelector('.mq-root-block')
+    ) as any;
+    input.setAttribute('value', JSON.stringify(style));
+    saveAsFile(mathQuiiFunc.html(), 'html.txt');
+    saveAsFile(JSON.stringify(style), 'css.txt');
   };
   return (
     <StyleComponent.HeaderContainer>

--- a/src/components/LeftSection/InputSelectionSection/InputBottomSelectionSection.tsx
+++ b/src/components/LeftSection/InputSelectionSection/InputBottomSelectionSection.tsx
@@ -1,36 +1,47 @@
-// import React from 'react';
-// import {
-//   InputLatexMathTopContent,
-//   InputLatexMathBottomContent,
-// } from '@src/constants/InputSection';
-// import Svg from '@src/components/Common/Svg';
-// import { InputLatexContent } from '@src/components/Common/LatexContent/style';
-// import * as StyledComponent from './style';
+/* eslint-disable react/no-array-index-key */
+import React from 'react';
+import {
+  InputLatexMathTopContent,
+  InputLatexMathBottomContent,
+} from '@src/constants/InputSection';
+import { LatexContent } from '@src/components/Common/LatexContent';
 
-// const InputBottomSelectionSection = () => {
-//   return (
-//     <>
-//       <StyledComponent.InputBottomSelectionSectionContainer>
-//         <StyledComponent.InputLatexContainer>
-//           {InputLatexMathTopContent.map((value, index) => (
-//             <InputLatexContent key={`dab${index}`} width="40" height="40">
-//               <Svg Svg={value.svg} />
-//             </InputLatexContent>
-//           ))}
-//           <InputLatexContent width="107" height="40">
-//             <StyledComponent.Dictionary>수식 사전</StyledComponent.Dictionary>
-//           </InputLatexContent>
-//         </StyledComponent.InputLatexContainer>
-//         <StyledComponent.InputLatexContainer>
-//           {InputLatexMathBottomContent.map((value, index) => (
-//             <InputLatexContent key={`dab${index}`} width="40" height="40">
-//               <Svg Svg={value.svg} />
-//             </InputLatexContent>
-//           ))}
-//         </StyledComponent.InputLatexContainer>
-//       </StyledComponent.InputBottomSelectionSectionContainer>
-//     </>
-//   );
-// };
+import * as StyledComponent from './style';
 
-// export default InputBottomSelectionSection;
+const InputBottomSelectionSection = () => {
+  return (
+    <>
+      <StyledComponent.InputBottomSelectionSectionContainer>
+        <StyledComponent.InputLatexContainer>
+          {InputLatexMathTopContent.map((value, index) => (
+            <LatexContent
+              key={`latex-dab${index}`}
+              svg={value.svg}
+              latex={value.latex}
+              name={value.name}
+              width="40"
+              height="40"
+            />
+          ))}
+          <StyledComponent.InputLatexContent width="102" height="40">
+            <StyledComponent.Dictionary>수식 사전</StyledComponent.Dictionary>
+          </StyledComponent.InputLatexContent>
+        </StyledComponent.InputLatexContainer>
+        <StyledComponent.InputLatexContainer>
+          {InputLatexMathBottomContent.map((value, index) => (
+            <LatexContent
+              key={`latex-${index}`}
+              width="40"
+              height="40"
+              svg={value.svg}
+              name={value.name}
+              latex={value.latex}
+            />
+          ))}
+        </StyledComponent.InputLatexContainer>
+      </StyledComponent.InputBottomSelectionSectionContainer>
+    </>
+  );
+};
+
+export default InputBottomSelectionSection;

--- a/src/components/LeftSection/InputSelectionSection/index.tsx
+++ b/src/components/LeftSection/InputSelectionSection/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Title from '@src/components/Common/Title';
 import InputTopSelectionSection from '@src/components/LeftSection/InputSelectionSection/InputTopSelectionSection';
-// import InputBottomSelectionSection from '@src/components/LeftSection/InputSelectionSection/InputBottomSelectionSection';
+import InputBottomSelectionSection from '@src/components/LeftSection/InputSelectionSection/InputBottomSelectionSection';
 import * as StyledComponent from './style';
 import { Box } from './Box';
 
@@ -12,6 +12,7 @@ const InputSelectionSectionContainer = () => {
         <Title title="입력 선택" />
         {/* <Box name="Glass" latex="\frac{ }{ }" /> */}
         <InputTopSelectionSection />
+        <InputBottomSelectionSection />
       </StyledComponent.InputSectionContainer>
     </>
   );

--- a/src/components/LeftSection/InputSelectionSection/style.tsx
+++ b/src/components/LeftSection/InputSelectionSection/style.tsx
@@ -11,10 +11,10 @@ export const InputSectionContainer = styled.div`
 
 export const InputTopSelectionSectionContainer = styled.div`
   width: 100%;
-  height: 48%;
+  height: 43%;
   border-bottom: 1px solid ${colors.borderGrey};
-  padding-top: 3px;
   padding-bottom: 5px;
+  margin-left: -10px;
 `;
 export const InputBottomSelectionSectionContainer = styled.div`
   width: 100%;

--- a/src/components/LeftSection/InputSelectionSection/style.tsx
+++ b/src/components/LeftSection/InputSelectionSection/style.tsx
@@ -11,13 +11,14 @@ export const InputSectionContainer = styled.div`
 
 export const InputTopSelectionSectionContainer = styled.div`
   width: 100%;
-  height: 43%;
-  border-bottom: 1px solid ${colors.borderGrey};
+  height: 46%;
   padding-bottom: 5px;
   margin-left: -10px;
 `;
 export const InputBottomSelectionSectionContainer = styled.div`
   width: 100%;
+  margin-top: 10px;
+  margin-left: -10px;
 `;
 export const InputLatexContainer = styled.div`
   display: flex;
@@ -26,4 +27,18 @@ export const InputLatexContainer = styled.div`
 `;
 export const Dictionary = styled.p`
   padding: 10px 20px;
+`;
+interface InputLatexContentProps {
+  width: string;
+  height: string;
+}
+export const InputLatexContent = styled.div<InputLatexContentProps>`
+  width: ${(props) => props.width}px;
+  height: ${(props) => props.height}px;
+  border: 1px solid ${colors.borderGrey};
+  padding-top: 10px;
+  &:hover {
+    cursor: pointer;
+    border: 1px solid ${colors.mainGreen};
+  }
 `;

--- a/src/components/MainSection/MainSection.tsx
+++ b/src/components/MainSection/MainSection.tsx
@@ -21,6 +21,7 @@ const MainSection = () => {
     dispatch(change(e.target.value));
   };
   const mainSectionRef = useRef<HTMLDivElement>(null);
+
   const [{ canDrop, isOver }, drop] = useDrop({
     accept: 'box',
     collect: (monitor) => ({

--- a/src/constants/InputSection.ts
+++ b/src/constants/InputSection.ts
@@ -80,7 +80,7 @@ export const InputLatexBottomContent: InputLatex[] = [
   {
     name: 'operator',
     svg: OPERATOR,
-    latex: '+=',
+    latex: '\\triangleq',
   },
   {
     name: 'matrix',
@@ -98,7 +98,7 @@ export const InputLatexMathTopContent: InputLatex[] = [
   {
     name: 'arrow',
     svg: ARROW,
-    latex: 'gets',
+    latex: '\\gets',
   },
   {
     name: 'inequality',
@@ -108,17 +108,17 @@ export const InputLatexMathTopContent: InputLatex[] = [
   {
     name: 'notoperator',
     svg: NOTOPERATOR,
-    latex: '\nless ',
+    latex: '\\nless ',
   },
   {
     name: 'figure',
     svg: FIGURE,
-    latex: '\rightangle ',
+    latex: '\\lfloor',
   },
   {
     name: 'unit',
     svg: UNIT,
-    latex: 'cmx ',
+    latex: '\\mx',
   },
   {
     name: 'specialsymbol',
@@ -140,21 +140,21 @@ export const InputLatexMathBottomContent: InputLatex[] = [
   {
     name: 'multiple',
     svg: MULTIPLE,
-    latex: '\times ',
+    latex: '\\times ',
   },
   {
     name: 'division',
     svg: DIVISION,
-    latex: 'div ',
+    latex: '\\div ',
   },
   {
     name: 'greece',
     svg: GREECE,
-    latex: 'alpha ',
+    latex: '\\alpha ',
   },
   {
     name: 'font',
     svg: FONT,
-    latex: 'E ',
+    latex: '\\epsilon',
   },
 ];

--- a/src/constants/InputSection.ts
+++ b/src/constants/InputSection.ts
@@ -85,7 +85,7 @@ export const InputLatexBottomContent: InputLatex[] = [
   {
     name: 'matrix',
     svg: MATRIX,
-    latex: '\\left[\\begin{matrix}3&4\\1&2\\\\end{matrix}\\right]',
+    latex: '\\begin{pmatrix}  &  \\  &  \\end{pmatrix}',
   },
   {
     name: 'inputdraw',
@@ -118,7 +118,7 @@ export const InputLatexMathTopContent: InputLatex[] = [
   {
     name: 'unit',
     svg: UNIT,
-    latex: '\\mx',
+    latex: '㎠',
   },
   {
     name: 'specialsymbol',

--- a/src/constants/InputSection.ts
+++ b/src/constants/InputSection.ts
@@ -32,7 +32,7 @@ export const InputLatexTopContent: InputLatex[] = [
   {
     name: 'multiply',
     svg: MULTPLY,
-    latex: '\frac{ }{ }',
+    latex: '\\frac{ }{ }',
   },
   {
     name: 'root',
@@ -42,7 +42,8 @@ export const InputLatexTopContent: InputLatex[] = [
   {
     name: 'pow',
     svg: POW,
-    latex: '\\combi{ }^{ }',
+
+    latex: '^{ }',
   },
   {
     name: 'integral',
@@ -57,39 +58,40 @@ export const InputLatexTopContent: InputLatex[] = [
   {
     name: 'galho',
     svg: GLOHO,
-    latex: 'left{combi{ }\right}',
+    latex: '\\left\\{\\right\\}',
   },
 ];
 export const InputLatexBottomContent: InputLatex[] = [
   {
     name: 'sin',
     svg: SIN,
-    latex: 'sin ^{ }',
+    latex: '\\sin ^{ }',
   },
   {
     name: 'decoration',
     svg: DECORATION,
-    latex: 'ddot{ }',
+    latex: '\\dot{ }\\dot{ }',
   },
   {
     name: 'limit',
     svg: LIMIT,
-    latex: 'lim _{ }^{ }combi{ }',
+    latex: '\\lim _{ }^{ }',
   },
   {
     name: 'operator',
     svg: OPERATOR,
-    latex: 'deltaequal ',
+    latex: '+=',
   },
   {
     name: 'matrix',
     svg: MATRIX,
-    latex: '\begin{matrix}&\\&end{matrix}',
+    latex: '\\left[\\begin{matrix}3&4\\1&2\\\\end{matrix}\\right]',
   },
   {
     name: 'inputdraw',
     svg: INPUTDRAW,
-    latex: '\begin{matrix}&\\&end{matrix}',
+    latex:
+      '\\begin{grid}\\cell{0000}&\\cell{0000}\\\\cell{0000}&\\cell{0000}\\end{grid}',
   },
 ];
 export const InputLatexMathTopContent: InputLatex[] = [

--- a/src/store/modules/getMathQuill.ts
+++ b/src/store/modules/getMathQuill.ts
@@ -1,9 +1,7 @@
 import { createAction, handleActions } from 'redux-actions';
 
 const GET_MATHQUILL_CONTAINER = ' GET_MATHQUILL_CONTAINER';
-
 export const getMathQuillContainer = createAction(GET_MATHQUILL_CONTAINER);
-
 export interface MathQuillContainerState {
   mathQuillContainer: any;
 }

--- a/src/utils/savefile.ts
+++ b/src/utils/savefile.ts
@@ -1,0 +1,9 @@
+const saveAsFile = (str: any, filename: string) => {
+  const hiddenElement = document.createElement('a');
+  hiddenElement.href = `data:attachment/text,${encodeURI(str)}`;
+  hiddenElement.target = '_blank';
+  hiddenElement.download = filename;
+  hiddenElement.click();
+};
+
+export default saveAsFile;


### PR DESCRIPTION
## 참고

<img width="647" alt="스크린샷 2020-12-03 오후 11 45 13" src="https://user-images.githubusercontent.com/22065725/101043404-a2218c80-35c1-11eb-816f-150d152f1d2f.png">
<img width="653" alt="스크린샷 2020-12-03 오후 11 45 22" src="https://user-images.githubusercontent.com/22065725/101043417-a483e680-35c1-11eb-954c-c71985123490.png">

## 체크 리스트
  - [x] html 저장
  - [x] css 저장
## 이야기할 사항
  - css의 경우 mathquill 영역의 모든 스타일을 가져오게 됩니다.(복잡할 수 있어서 나중에 찾아보겠습니다.)
  - html의 경우 mathquill 영역의 html을 가져오게 됩니다.
  - file을 save하기 위해서 utils 폴더에 saveFile 파일을 작성하였습니다.
