### PR TITLE
fix : css 관련 잔버그 수정

### DIFF
--- a/src/components/LeftSection/InputSelectionSection/style.tsx
+++ b/src/components/LeftSection/InputSelectionSection/style.tsx
@@ -60,5 +60,6 @@ export const InputLatexContent = styled.div<InputLatexContentProps>`
   transition-duration: 0.4s;
   &:hover {
     background-color: ${colors.lightGrey};
+    cursor: pointer;
   }
 `;

--- a/src/components/MainSection/LatexSection/style.tsx
+++ b/src/components/MainSection/LatexSection/style.tsx
@@ -1,6 +1,10 @@
 import styled from 'styled-components';
 import colors from '@src/utils/colors';
 
+export const LaTex = styled.div`
+  overflow: hidden;
+`;
+
 export const Handle = styled.div`
   display: flex;
   cursor: row-resize;
@@ -15,6 +19,7 @@ export const Handle = styled.div`
 
 export const Content = styled.div`
   display: flex;
+  height: 100%;
   textarea {
     background-color: transparent;
     color: ${colors.white};

--- a/src/components/MainSection/LatexSection/style.tsx
+++ b/src/components/MainSection/LatexSection/style.tsx
@@ -26,6 +26,5 @@ export const Content = styled.div`
     padding: 10px;
     min-width: 96%;
     min-height: 95%;
-    margin: auto;
   }
 `;

--- a/src/components/MainSection/MainSectionStyle.ts
+++ b/src/components/MainSection/MainSectionStyle.ts
@@ -23,7 +23,7 @@ export const LaTeX = styled.div<{ height: number }>`
   height: ${(props) => props.height}%;
   display: flex;
   flex-direction: column;
-  overflow: auto;
+  overflow: hidden;
 `;
 
 export const Tab = styled.div`


### PR DESCRIPTION
- 그래프 영역 활성화 시,  LaTex 영역의 textarea 시작 위치가 움직여서 margin : auto를 제거하여 고정했습니다.
- 수식 사전 부분의 마우스가 pointer로 되어있지 않아서 변경했습니다.